### PR TITLE
modified logging to use emitted log object from hydra

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,10 +140,7 @@ class HydraExpress {
         * @param {string} entry - log entry
         */
         hydra.on('log', (entry) => {
-          let msg = Utils.safeJSONParse(entry);
-          if (msg) {
-            this.log(msg.type, msg.message);
-          }
+          this.log(entry.type, entry.message);
         });
 
         if (config.jwtPublicCert) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-hydra-express",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "A module which wraps Hydra and ExpressJS to provide an out of the box microservice which can support API routes and handlers.",
   "author": {
     "name": "Carlos Justiniano"
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/flywheelsports/fwsp-hydra-express#readme",
   "dependencies": {
-    "fwsp-hydra": "0.11.2",
+    "fwsp-hydra": "0.11.4",
     "bluebird": "3.4.6",
     "body-parser": "1.15.2",
     "bunyan": "1.8.4",


### PR DESCRIPTION
modified logging to use emitted log object from hydra without JSON parsing it, as that's no longer required