### PR TITLE
expose decodeJwtToken 

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,7 @@ class HydraExpress {
   constructor() {
     this.config = null;
     this.server = null;
+    this.jwtAuth = jwtAuth;
     this.appLogger = defaultLogger();
     this.registeredPlugins = [];
   }
@@ -546,15 +547,6 @@ class HydraExpress {
   }
 
   /**
-  * @name _decodeJwtToken
-  * @summary Helper function for decoding JWT token
-  * @return {function} Promise that resolves with decoded JWT token
-  */
-  _decodeJwtToken(token) {
-    return jwtAuth.verifyToken(token);
-  }
-
-  /**
   * @name _validateJwtToken
   * @summary Express middleware to validate a JWT sent via the req.authorization header
   * @return {function} Middleware function
@@ -571,7 +563,7 @@ class HydraExpress {
       } else {
         let token = authHeader.split(' ')[1];
         if (token) {
-          return this._decodeJwtToken(token)
+          return jwtAuth.verifyToken(token)
             .then((decoded) => {
               req.authToken = decoded;
               next();
@@ -704,15 +696,6 @@ class IHydraExpress extends HydraExpress {
    */
   sendResponse(httpCode, res, data) {
     super._sendResponse(httpCode, res, data);
-  }
-
-  /**
-  * @name decodeJwtToken
-  * @summary Helper function for decoding JWT token
-  * @return {function} Promise that resolves with decoded JWT token
-  */
-  decodeJwtToken(token) {
-    return super._decodeJwtToken(token);
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -69,7 +69,6 @@ class HydraExpress {
   constructor() {
     this.config = null;
     this.server = null;
-    this.jwtAuth = jwtAuth;
     this.appLogger = defaultLogger();
     this.registeredPlugins = [];
   }
@@ -232,6 +231,15 @@ class HydraExpress {
   */
   getHydra() {
     return hydra;
+  }
+
+  /**
+  * @name getJwtAuth
+  * @summary Retrieve the underlying jwtAuth object
+  * @return {object} jwtAuth - jwtAuth object
+  */
+  getJwtAuth() {
+    return jwtAuth;
   }
 
   /**
@@ -662,6 +670,15 @@ class IHydraExpress extends HydraExpress {
   */
   getHydra() {
     return super.getHydra();
+  }
+
+  /**
+  * @name getJwtAuth
+  * @summary Retrieve the underlying jwtAuth object
+  * @return {object} jwtAuth - jwtAuth object
+  */
+  getJwtAuth() {
+    return super.getJwtAuth();
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -546,6 +546,15 @@ class HydraExpress {
   }
 
   /**
+  * @name _decodeJwtToken
+  * @summary Helper function for decoding JWT token
+  * @return {function} Promise that resolves with decoded JWT token
+  */
+  _decodeJwtToken(token) {
+    return jwtAuth.verifyToken(token);
+  }
+
+  /**
   * @name _validateJwtToken
   * @summary Express middleware to validate a JWT sent via the req.authorization header
   * @return {function} Middleware function
@@ -562,7 +571,7 @@ class HydraExpress {
       } else {
         let token = authHeader.split(' ')[1];
         if (token) {
-          return jwtAuth.verifyToken(token)
+          return this._decodeJwtToken(token)
             .then((decoded) => {
               req.authToken = decoded;
               next();
@@ -695,6 +704,15 @@ class IHydraExpress extends HydraExpress {
    */
   sendResponse(httpCode, res, data) {
     super._sendResponse(httpCode, res, data);
+  }
+
+  /**
+  * @name decodeJwtToken
+  * @summary Helper function for decoding JWT token
+  * @return {function} Promise that resolves with decoded JWT token
+  */
+  decodeJwtToken(token) {
+    return super._decodeJwtToken(token);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-hydra-express",
-  "version": "0.15.15",
+  "version": "0.15.16",
   "description": "A module which wraps Hydra and ExpressJS to provide an out of the box microservice which can support API routes and handlers.",
   "author": {
     "name": "Carlos Justiniano"


### PR DESCRIPTION
This gives services extending Hydra-Express direct access to the jwtAuth.verifyToken method (currently only indirectly available through the validateJwtToken middleware). 