### PR TITLE
runtimeConfig fix for plugins, extract jwt-auth plugin

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -71,7 +71,7 @@ In the example above, the `serviceInfo` on the then statement returns an object 
 
 ## Logging and error reporting
 
-HydraExpress includes a `log` member which allows you to log into to both the console and log file.  
+HydraExpress includes a `log` member which allows you to log into to both the console and log file.
 
 ```javascript
 hydraExpress.log('error', message);
@@ -208,15 +208,10 @@ sendResponse(httpCode, res, data)
 ```
 
 #### validateJwtToken
-Express middleware to validate a JWT sent via the req.authorization header
-```javascript
-/**
-* @name validateJwtToken
-* @summary Express middleware to validate a JWT sent via the req.authorization header
-* @return {function} Middleware function
-*/
-validateJwtToken()
-```
+
+*DEPRECATED*
+
+This functionality has been extracted to the [jwt-auth plugin](http://github.com/flywheelsports/hydra-express-plugin-jwt-auth).
 
 ## Hydra / Express configuration
 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,6 @@ const http = require('http');
 const moment = require('moment');
 const path = require('path');
 const responseTime = require('response-time');
-const jwtAuth = require('fwsp-jwt-auth');
 
 let app = express();
 
@@ -222,15 +221,6 @@ class HydraExpress {
   */
   getHydra() {
     return hydra;
-  }
-
-  /**
-  * @name getJwtAuth
-  * @summary Retrieve the underlying jwtAuth object
-  * @return {object} jwtAuth - jwtAuth object
-  */
-  getJwtAuth() {
-    return jwtAuth;
   }
 
   /**
@@ -516,45 +506,6 @@ class HydraExpress {
     serverResponse.sendResponse(httpCode, res, data);
   }
 
-  /**
-  * @name _validateJwtToken
-  * @summary Express middleware to validate a JWT sent via the req.authorization header
-  * @return {function} Middleware function
-  */
-  _validateJwtToken() {
-    return (req, res, next) => {
-      let authHeader = req.headers.authorization;
-      if (!authHeader) {
-        this.sendResponse(ServerResponse.HTTP_UNAUTHORIZED, res, {
-          result: {
-            reason: 'Invalid token'
-          }
-        });
-      } else {
-        let token = authHeader.split(' ')[1];
-        if (token) {
-          return jwtAuth.verifyToken(token)
-            .then((decoded) => {
-              req.authToken = decoded;
-              next();
-            })
-            .catch((err) => {
-              this.sendResponse(ServerResponse.HTTP_UNAUTHORIZED, res, {
-                result: {
-                  reason: err.message
-                }
-              });
-            });
-        } else {
-          this.sendResponse(ServerResponse.HTTP_UNAUTHORIZED, res, {
-            result: {
-              reason: 'Invalid token'
-            }
-          });
-        }
-      }
-    };
-  }
 }
 
 /* ************************************************************************************************ */
@@ -647,15 +598,6 @@ class IHydraExpress extends HydraExpress {
   }
 
   /**
-  * @name getJwtAuth
-  * @summary Retrieve the underlying jwtAuth object
-  * @return {object} jwtAuth - jwtAuth object
-  */
-  getJwtAuth() {
-    return super.getJwtAuth();
-  }
-
-  /**
   * @name getRuntimeConfig
   * @summary Retrieve loaded configuration object
   * @return {object} config - immutable object
@@ -698,14 +640,6 @@ class IHydraExpress extends HydraExpress {
     super._sendResponse(httpCode, res, data);
   }
 
-  /**
-  * @name validateJwtToken
-  * @summary Express middleware to validate a JWT sent via the req.authorization header
-  * @return {function} Middleware function
-  */
-  validateJwtToken() {
-    return super._validateJwtToken();
-  }
 }
 
 module.exports = new IHydraExpress;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-express",
-  "version": "1.3.8",
+  "version": "1.4.0",
   "description": "A module which wraps Hydra and ExpressJS to provide an out of the box microservice which can support API routes and handlers.",
   "author": {
     "name": "Carlos Justiniano"


### PR DESCRIPTION
call plugin.setConfig with runtime config (loaded from redis during hydra.init) rather than initial config.json

also removed the jwtAuth.loadCerts since the convention has been to do that in the service entrypoint script. I don't think this should be tucked into hydra-express - too magical, and in this case broken (since it isn't called with the runtimeConfig from redis). agree with @cjus that it would probably best be implemented as a plugin.