### PR TITLE
allow registerRoutesCallback to return a promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -433,45 +433,48 @@ class HydraExpress {
      * @description listen handler for server.
      */
     this.server.listen(this.config.hydra.servicePort, () => {
-      this.registerRoutesCallback && this.registerRoutesCallback();
+      Promise.resolve(this.registerRoutesCallback && this.registerRoutesCallback())
+        .then(routesRegistered => this._postRouteSetup());
+    });
+  }
 
-      app.use('/*', (req, res) => {
-        res.sendFile(path.resolve(this.config.appPath + '/index.html'));
-      });
+  _postRouteSetup() {
+    app.use('/*', (req, res) => {
+      res.sendFile(path.resolve(this.config.appPath + '/index.html'));
+    });
 
-      /**
-      * Post middleware init. Make sure to do this last.
-      */
+    /**
+    * Post middleware init. Make sure to do this last.
+    */
 
-      /**
-      * @param {object} req - express request object
-      * @param {object} res - express response object
-      * @param {function} next - express next handler
-      */
-      app.use((req, res, next) => {
-        let err = new Error('Not Found');
-        err.status = ServerResponse.HTTP_NOT_FOUND;
-        next(err);
-      });
+    /**
+    * @param {object} req - express request object
+    * @param {object} res - express response object
+    * @param {function} next - express next handler
+    */
+    app.use((req, res, next) => {
+      let err = new Error('Not Found');
+      err.status = ServerResponse.HTTP_NOT_FOUND;
+      next(err);
+    });
 
-      /**
-      * @param {object} err - express err object
-      * @param {object} req - express request object
-      * @param {object} res - express response object
-      * @param {function} _next - express next handler
-      */
-      app.use((err, req, res, _next) => {
-        let errCode = err.status || ServerResponse.HTTP_SERVER_ERROR;
-        if (err.status !== ServerResponse.HTTP_NOT_FOUND) {
-          this.appLogger.fatal({
-            event: 'error',
-            error: err.name,
-            stack: err.stack
-          });
-        }
-        res.status(errCode).json({
-          code: errCode
+    /**
+    * @param {object} err - express err object
+    * @param {object} req - express request object
+    * @param {object} res - express response object
+    * @param {function} _next - express next handler
+    */
+    app.use((err, req, res, _next) => {
+      let errCode = err.status || ServerResponse.HTTP_SERVER_ERROR;
+      if (err.status !== ServerResponse.HTTP_NOT_FOUND) {
+        this.appLogger.fatal({
+          event: 'error',
+          error: err.name,
+          stack: err.stack
         });
+      }
+      res.status(errCode).json({
+        code: errCode
       });
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-express",
-  "version": "1.4.19",
+  "version": "1.4.20",
   "description": "A module which wraps Hydra and ExpressJS to provide an out of the box microservice which can support API routes and handlers.",
   "author": {
     "name": "Carlos Justiniano"


### PR DESCRIPTION
Wait for registerRoutesCallback to resolve if it returns a promise before the wildcard route handler and post-middleware init.