### PR TITLE
Safely introduce body-parser-config #85 functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -382,8 +382,20 @@ class HydraExpress {
     app.use(helmet.hidePoweredBy({setTo: `${hydra.getServiceName()}/${hydra.getInstanceVersion()}`}));
     app.use(helmet.hsts({maxAge: ninetyDaysInMilliseconds}));
 
-    app.use(bodyParser.json());
-    app.use(bodyParser.urlencoded({extended: false}));
+    if (this.config.cors) {
+      app.use(cors(Object.assign({}, this.config.cors)));
+    } else {
+      app.use(cors());
+    }
+
+    if (this.config.bodyParser) {
+      let bodyParserConfig = Object.assign({json: {}, urlencoded: {extended: false}}, this.config.bodyParser);
+      app.use(bodyParser.json(bodyParserConfig.json));
+      app.use(bodyParser.urlencoded(bodyParserConfig.urlencoded));
+    } else {
+      app.use(bodyParser.json());
+      app.use(bodyParser.urlencoded({extended: false}));
+    }
 
     this.registerMiddlewareCallback && this.registerMiddlewareCallback();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-express",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-express",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "A module which wraps Hydra and ExpressJS to provide an out of the box microservice which can support API routes and handlers.",
   "author": {
     "name": "Carlos Justiniano"


### PR DESCRIPTION
The functionality for a cors and body parser enhancement was introduced into an experimental version of Hydra Express but was not merged into the main branch.

https://github.com/flywheelsports/hydra-express/pull/85/commits/ab51a20b56fff05d6483e7a183c30c268f322c88

This PR safely introduces that functionality. To use this new feature the user needs to add a `cors` and or `bodyParser` branch to their service's config.json file.