### PR TITLE
fix(cors): add preflight to validate cors rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -322,7 +322,6 @@ class HydraExpress {
    * @return {undefined}
    */
   initService() {
-    app.use(cors());
     app.use(responseTime());
 
     /**
@@ -388,8 +387,10 @@ class HydraExpress {
 
     if (this.config.cors) {
       app.use(cors(Object.assign({}, this.config.cors)));
+      app.options(cors(Object.assign({}, this.config.cors)));
     } else {
       app.use(cors());
+      app.options(cors());
     }
 
     if (this.config.bodyParser) {


### PR DESCRIPTION
# Cors Pre-Flight validate Cors Rules

## Description

In the beginning of the init function, it was initializing cors and further down the code it was initialized again. The first initialization has been removed.

While developing my microservice I was in need to provide credentials = true within my cors options and realized that no matter what cors pre-flight would return allowed-origins with the * wildcard.
EDIT: If credentials = true is provided, allowed-origins cannot be the * wildcard.
Allowing express to also provide the cors rules within the preflight solved this issue.

## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Having credentials = true within the cors options was causing an issue with communicating with the microservice running with hydra-express. This has been tested by sending a session cookie to the microservice with success while also running hydra-express' unit tests.

## Checklist:

- [X ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [X ] My changes generate no new warnings
- [X ] New and existing unit tests pass locally with my changes