### PR TITLE
End main process if redis is unavailable at boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ scratch.*
 node_modules/
 ./properties.js
 .vscode
+yarn.lock

--- a/index.js
+++ b/index.js
@@ -299,6 +299,10 @@ class HydraExpress {
         this.config = config;
         return Promise.series(this.registeredPlugins, (plugin) => plugin.setConfig(config));
       })
+      .catch((err) => {
+        this.log('error', {err});
+        process.exit(1);
+      })
       .then(() => hydra.registerService())
       .then((_serviceInfo) => {
         serviceInfo = _serviceInfo;

--- a/index.js
+++ b/index.js
@@ -537,7 +537,6 @@ class HydraExpress {
   _sendResponse(httpCode, res, data) {
     serverResponse.sendResponse(httpCode, res, data);
   }
-
 }
 
 /* ************************************************************************************************ */
@@ -674,7 +673,6 @@ class IHydraExpress extends HydraExpress {
   sendResponse(httpCode, res, data) {
     super._sendResponse(httpCode, res, data);
   }
-
 }
 
 module.exports = new IHydraExpress;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydra-express",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "A module which wraps Hydra and ExpressJS to provide an out of the box microservice which can support API routes and handlers.",
   "author": {
     "name": "Carlos Justiniano"


### PR DESCRIPTION
When Redis is not reachable upon `start()` execution, it happens before `process.on('cleanup', () => {...})` is wired.
The result is a stale `hydra-express` that cannot be collected by the container, thus cannot be restarted.

In this case a Docker `HEALTHCHECK` or a Kubernetes `livenessProbe` for the deployment/.../container could help terminating and starting a new deployment.

This splits the try/catch block in 2, the first block will immediately `process.exit(1);`.
The second will trigger `process.emit('cleanup')` upon an exception and that will be handled by the listener, properly shutdown the service.